### PR TITLE
Allow the app to be configured with an MDM

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,31 @@ Project uses CocoaPods for dependencies management. To build the project you nee
 pod install
 ```
 
+## Configure app with an MDM (Mobile Device Management)
+
+When deploying the application with an MDM solution, the parameters can be overloaded with a managed configuration pushed to the phone. The following table shows the keys associated with the parameters.
+
+|Parameter name|Key|Type|
+|---|---|---|
+|Device identifier|device_id_preference|string|
+|Server URL|server_url_preference|string|
+|Location accuracy|accuracy_preference|string|
+|Frequency|frequency_preference|integer|
+|Distance|distance_preference|integer|
+|Angle|angle_preference|integer|
+|Offline buffering|buffer_preference|string|
+
+When a parameter is configured through MDM, it is hidden in UI and cannot be changed by the user.
+
 ## Team
 
+### Main contributors
+
 - Anton Tananaev ([anton@traccar.org](mailto:anton@traccar.org))
+
+### Secondary contributors
+
+- Axel Rieben
 
 ## License
 

--- a/TraccarClient/MainViewController.swift
+++ b/TraccarClient/MainViewController.swift
@@ -26,6 +26,7 @@ class MainViewController: IASKAppSettingsViewController {
         title = NSLocalizedString("Traccar Client", comment: "")
         showCreditsFooter = false
         neverShowPrivacySettings = true
+        hideManagedSettings()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -65,7 +66,7 @@ class MainViewController: IASKAppSettingsViewController {
                 } else if frequency <= 0 {
                     self.showError("Invalid frequency value")
                 } else {
-                    StatusViewController.addMessage(NSLocalizedString("Service created", comment: ""))
+                    StatusViewController.addStartMessage()
                     AppDelegate.instance.trackingController = TrackingController()
                     AppDelegate.instance.trackingController?.start()
                 }
@@ -77,4 +78,13 @@ class MainViewController: IASKAppSettingsViewController {
         }
     }
     
+    // Settings that are configured through a MDM are hidden and cannot be changed by the user
+    func hideManagedSettings() {
+        if let managedConfiguration = UserDefaults.standard.object(forKey: "com.apple.configuration.managed") as? [String: Any?] {
+            let configWithoutNil = managedConfiguration.compactMapValues{ $0 }
+            // Status cannot be set via managed configuration and is always set by user
+            let keysWithoutStatus = configWithoutNil.keys.filter { $0 != "service_status_preference" }
+            setHiddenKeys(Set(keysWithoutStatus), animated: false)
+        }
+    }
 }

--- a/TraccarClient/StatusViewController.swift
+++ b/TraccarClient/StatusViewController.swift
@@ -23,6 +23,26 @@ class StatusViewController: UITableViewController {
     
     static var messages = [String]()
     
+    class func addStartMessage() {
+        var message = NSLocalizedString("Service created", comment: "")
+        message += "\n\nDevice identifier: "
+        message += UserDefaults.standard.string(forKey: "device_id_preference") ?? ""
+        message += "\nServer URL: "
+        message += UserDefaults.standard.string(forKey: "server_url_preference") ?? ""
+        message += "\nLocation accuracy: "
+        message += UserDefaults.standard.string(forKey: "accuracy_preference") ?? ""
+        message += "\nFrequency: "
+        message += String(UserDefaults.standard.double(forKey: "frequency_preference"))
+        message += "\nDistance: "
+        message += String(UserDefaults.standard.double(forKey: "distance_preference"))
+        message += "\nAngle: "
+        message += String(UserDefaults.standard.double(forKey: "angle_preference"))
+        message += "\nOffline buffering: "
+        message += UserDefaults.standard.bool(forKey: "buffer_preference") ? "On" : "Off"
+        
+        addMessage(message)
+    }
+    
     class func addMessage(_ message: String) {
         let formatter = DateFormatter()
         formatter.dateFormat = "HH:mm - "
@@ -74,6 +94,9 @@ class StatusViewController: UITableViewController {
         if cell == nil {
             cell = UITableViewCell(style: .default, reuseIdentifier: cellIdentifier)
         }
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 24
+        cell?.textLabel?.numberOfLines = 0
         cell?.textLabel?.text = StatusViewController.messages[indexPath.row]
         return cell!
     }


### PR DESCRIPTION
This PR allows you to configure the application with an MDM (Mobile Device Management). When settings are configured with MDM they are hidden in the user interface. To inform the user of the settings that are currently configured, these are displayed at startup in the "Status" screen. To respect the user's privacy, the activation or deactivation of tracking cannot be configured by MDM.

The functionality has been tested with SimpleMDM and AirWatch MDMs.

To simulate sending MDM parameters to an iOS simulator, it is possible to use this command:
```
xcrun simctl spawn booted defaults write org.traccar.client.TraccarClient com.apple.configuration.managed -dict "device_id_preference" "john.doe" "server_url_preference" "https://traccar.com:5555" "accuracy_preference" "high" "frequency_preference" "300" "distance_preference" "50" "angle_preference" "100" "buffer_preference" "0"
```